### PR TITLE
Avoid raising an exception at the command prompt

### DIFF
--- a/xradios/core/metadata.py
+++ b/xradios/core/metadata.py
@@ -20,18 +20,12 @@ class MetadataState:
 
 class LoadMetadata(metaclass=ABCMeta):
 
-    station = None
-
     @abstractmethod
     def metadata(self, station):
         pass
 
-    def get(self):
-        return self.metadata(self.station)
-
     def __call__(self, station):
-        self.station = station
-        return self.get()
+        return self.metadata(station)
 
 
 class LoadMetadataFromPlugin(LoadMetadata):

--- a/xradios/tui/commands.py
+++ b/xradios/tui/commands.py
@@ -47,10 +47,14 @@ def listview_handler(event):
 
 
 def prompt_handler(event):
-    variables = COMMAND_GRAMMAR.match(event.current_buffer.text).variables()
-    command = variables.get("command")
-    if has_command_handler(command):
-        call_command_handler(command, event, variables=variables)
+    try:
+        variables = COMMAND_GRAMMAR.match(event.current_buffer.text).variables()
+    except Exception:
+        return
+    else:
+        command = variables.get("command")
+        if has_command_handler(command):
+            call_command_handler(command, event, variables=variables)
 
 
 def cmd(name):


### PR DESCRIPTION
Avoid raising an exception when pressing enter at the command
prompt without entering any commands.
