### PR TITLE
Bump notify-send from 0.0.16 to 0.0.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 prompt-toolkit>=3.0.8
-notify-send>=0.0.16 
+notify-send>=0.0.20
 Pygments>=2.7.3
 streamscrobbler3>=0.0.4
 python-mpv>=0.5.2

--- a/xradios/core/server.py
+++ b/xradios/core/server.py
@@ -1,25 +1,15 @@
-# import logging
-import os
-import re
 import sys
-from dataclasses import dataclass
-from dataclasses import field
-
-from functools import partial
-
 import signal
-from signal import SIGTERM
 
 from xmlrpc.server import SimpleXMLRPCServer
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 
-# from http.server import BaseHTTPRequestHandler
-from pluginbase import PluginBase
-from pyradios import RadioBrowser
-
-
+from xradios.core.metadata import metadata_manager
 from xradios.core.player import player
 from xradios.logger import log
+
+
+from pyradios import RadioBrowser
 
 
 rb = RadioBrowser()
@@ -61,9 +51,6 @@ def remote_search(**kwargs):
     term = kwargs.get("term")
     result = getattr(rb, "stations_by_{}".format(command[2:]))(term)
     return result
-
-
-from xradios.core.metadata import metadata_manager
 
 
 @cmd("station_info")
@@ -125,14 +112,11 @@ def run(host="", port=10000):
         signal.SIGTERM,
         lambda signo, frame: sigterm_handler(signo, frame, server)
     )
-
     log.info(f"Serving XML-RPC port: {port}")
     server.serve_forever()
 
 
 def main():
-    import sys
-
     try:
         run()
     except KeyboardInterrupt:

--- a/xradios/tui/utils.py
+++ b/xradios/tui/utils.py
@@ -1,6 +1,5 @@
 from dataclasses import asdict
 from dataclasses import dataclass
-from dataclasses import field
 from collections import UserList
 
 
@@ -13,47 +12,36 @@ class Station:
     homepage: str
     tags: str
 
+    @classmethod
+    def fields(cls):
+        return cls.__annotations__.keys()
 
     def serialize(self):
         return asdict(self)
 
     def __str__(self):
-        return "{:>4} | {:<30} | tags: {} \n".format(
-            self.index, self.name[0:30], self.tags
+        return "{:>4} | {:<40.40} | tags: {} \n".format(
+            self.index, self.name, self.tags
         )
 
 
-class StationList:
-    def __init__(self, *args):
-        self.new(*args)
+class StationList(UserList):
+    def __init__(self, *stations):
+        self.data = []
+        if stations:
+            for i, s in enumerate(stations, 1):
+                kwargs = dict(
+                    filter(
+                        lambda elem: elem[0] in Station.fields(), s.items()
+                    )
+                )
+                self.data.append(Station(index=i, **kwargs))
 
     def new(self, *args):
-        if not args:
-            return
-
-        self._list = []
-        for index, obj in enumerate(args, 1):
-            o = Station(
-                index=index,
-                stationuuid=obj["stationuuid"],
-                name=obj["name"],
-                url=obj["url"],
-                homepage=obj["homepage"],
-                tags=obj["tags"],
-            )
-            self._list.append(o)
-
-    def __getitem__(self, index):
-        return self._list[index]
-
-    def __len__(self):
-        return len(self._list)
-
-    def __repr__(self):
-        return "<StationList()>"
+        return self.__init__(*args)
 
     def __str__(self):
-        return "".join(str(s) for s in self)
+        return "".join(str(s) for s in self.data)
 
 
 stations = StationList()


### PR DESCRIPTION
- Increases the timeout
- Remove wait time
- Remove line number
- Update Readme
- Update requirements
- Allow users to add bookmarks
- Remove services.py
- Fix CR+LF of the string provided by the stramscrobbler
- Improve the internal structure of the StationList class
- Clean up imports
- Bump notify-send from 0.0.16 to 0.0.20
