### PR TITLE
Rename the list command to search

### DIFF
--- a/xradios/tui/commands.py
+++ b/xradios/tui/commands.py
@@ -100,7 +100,11 @@ def pause(event, **kwargs):
 @cmd("search")
 def search(event, **kwargs):
     query = {}
-    query["command"] = kwargs["variables"].get("subcommand")
+    list_buffer = event.app.layout.get_buffer_by_name(LISTVIEW_BUFFER)
+    query["command"] = kwargs["variables"].get("subcommand")[2:] 
+    # TODO:
+    # remover by dos subcomandos
+    # [2: ] remove the by from subcommand
     query["term"] = kwargs["variables"].get("term")
     response = proxy.remote_search(**query)
     stations.new(*response)


### PR DESCRIPTION
- Increases the timeout
- Remove wait time
- Remove line number
- Update Readme
- Update requirements
- Allow users to add bookmarks
- Remove services.py
- Fix CR+LF of the string provided by the stramscrobbler
- Improve the internal structure of the StationList class
- Clean up imports
- Bump notify-send from 0.0.16 to 0.0.20
- Rename the list command to search
- Fix: Rename the list command to search
