### PR TITLE
Improve DisplayBuffer update logic

### DIFF
--- a/xradios/tui/buffers/display.py
+++ b/xradios/tui/buffers/display.py
@@ -14,41 +14,39 @@ log = logging.getLogger('xradios')
 
 
 class DisplayBuffer(Buffer):
-    def __init__(self, *args, **kwargs):
-        content = kwargs.get("content", "")
+    def __init__(self, **kwargs):
+        content = kwargs.get('content', '')
         super().__init__(
-            document=Document(content, 0),
-            read_only=True,
-            name=DISPLAY_BUFFER
+            document=Document(content, 0), read_only=True, name=DISPLAY_BUFFER
         )
+        self.metadata = None
 
     def clear(self):
-        self.set_document(Document("", 0), bypass_readonly=True)
+        self.set_document(Document('', 0), bypass_readonly=True)
 
     async def run(self):
         while True:
             try:
-                metadata = proxy.now_playing()
-            except:
+                result = proxy.now_playing()
+            except Exception:
                 pass
             else:
-                if metadata and all(metadata.values()):
-                    notification(
-                        metadata.get('name'),
-                        message=metadata.get('song'),
-                        app_name='xradios'
-                    )
-
-                    self.update(metadata)
-            await asyncio.sleep(120)
+                if result != self.metadata and all(result.values()):
+                    self.metadata = result
+                    self.update(result)
+            await asyncio.sleep(30)
 
     def update(self, metadata):
-        log.info(metadata)
-        if metadata.get('song'):
-            content = '\n{name:<30} {homepage}\n\n{song}'.format(**metadata)
-        else:
-            content = "\n{name:<30}\n\n{homepage}".format(**metadata)
+        name = metadata.get('name')
+        homepage = metadata.get('homepage')
+        song = metadata.get('song')
 
+        if song:
+            content = f'\n{name:<30} {homepage}\n\n{song}'
+            notification(name, message=song, app_name='xradios', timeout=5000)
+        else:
+            content = f'\n{name:<30}\n\n{homepage}'
+        
         self.set_document(Document(content, 0), bypass_readonly=True)
 
 


### PR DESCRIPTION
This commit updates the display buffer to notify the user of the
currently playing song. It does this by calling the `proxy.now_playing()`
method every 30 seconds and updating the buffer with the results.
If the song changes, a notification is also displayed.

Changes:

    - Implemented metadata comparison to prevent unnecessary updates.
    - Restructured the `run` method to handle exceptions more robustly.
    - Adjusted notification timeout for better user experience.
